### PR TITLE
Added color/console support for Windows

### DIFF
--- a/JustMetadata.py
+++ b/JustMetadata.py
@@ -9,6 +9,8 @@ be extensible to easily add new functionality.
 
 from common import helpers
 from common import orchestra
+from colorama import init
+init()
 
 if __name__ == '__main__':
 

--- a/common/helpers.py
+++ b/common/helpers.py
@@ -7,7 +7,7 @@ import os
 
 
 def print_header():
-    os.system('clear')
+    os.system('cls'if os.name == 'nt' else 'clear')
     print "#" * 80
     print "#" + " " * 32 + "Just-Metadata" + " " * 33 + "#"
     print "#" * 80


### PR DESCRIPTION
Noticed that some of the escape sequences for color and the command for clearing the screen were not functional on Windows. 

As colorama is a dependency for shodan, it should be available for use in any python installation. Colorama will translate ANSI escape sequences to the proper Windows API calls automagically. 

Also modified the code for clearing the screen to account for execution on Windows.
