### PR TITLE
Fix feodo threat list

### DIFF
--- a/modules/intelgathering/feed_urls.py
+++ b/modules/intelgathering/feed_urls.py
@@ -149,7 +149,7 @@ class IntelGather:
         try:
             print "Grabbing Feodo list..."
             req = urllib2.Request(
-                'http://rules.emergingthreats.net/blockrules/compromised-ips.txt')
+                'https://feodotracker.abuse.ch/blocklist/?download=ipblocklist')
             req.add_header(
                 'User-agent', 'Mozilla/5.0 (Windows NT 6.3; rv:36.0) Gecko/20100101 Firefox/36.0')
             response = urllib2.urlopen(req)


### PR DESCRIPTION
The wrong url was being used for the feodo threat list.  This has since been corrected to the right URL
